### PR TITLE
fix: upgrade tracing-subscriber to 0.30.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1858,7 +1858,7 @@ dependencies = [
  "petgraph 0.7.1",
  "pico-args",
  "regex",
- "regex-syntax 0.8.6",
+ "regex-syntax",
  "sha3",
  "string_cache",
  "term",
@@ -1872,7 +1872,7 @@ version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5baa5e9ff84f1aefd264e6869907646538a52147a755d494517a8007fb48733"
 dependencies = [
- "regex-automata 0.4.10",
+ "regex-automata",
  "rustversion",
 ]
 
@@ -1963,11 +1963,11 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -2044,12 +2044,11 @@ checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2251,12 +2250,6 @@ dependencies = [
  "tokio-stream",
  "tracing",
 ]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking"
@@ -2862,17 +2855,8 @@ checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.10",
- "regex-syntax 0.8.6",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2883,14 +2867,8 @@ checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.6",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -4445,14 +4423,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "serde",
  "serde_json",
  "sharded-slab",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ async-trait = "0.1.78"
 thiserror = "1.0.58"
 anyhow = "1.0.97"
 tracing = "0.1.40"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
+tracing-subscriber = { version = "0.3.20", features = ["env-filter", "json"] }
 tracing-opentelemetry = "0.28.0"
 opentelemetry-otlp = { version = "0.27.0", features = [
   "http-proto",


### PR DESCRIPTION
from check-code:

```
Crate:     tracing-subscriber
Version:   0.3.19
Title:     Logging user input may result in poisoning logs with ANSI escape sequences
error: 1 vulnerability found!
warning: 2 allowed warnings found
Date:      2025-08-29
ID:        RUSTSEC-2025-0055
URL:       https://rustsec.org/advisories/RUSTSEC-2025-0055
Solution:  Upgrade to >=0.3.20
Dependency tree:
tracing-subscriber 0.3.19
├── tracing-opentelemetry 0.28.0
│   ├── stablesats-shared 0.12.9-dev
│   │   ├── user-trades 0.12.9-dev
│   │   │   └── stablesats 0.12.9-dev
│   │   ├── stablesats-ledger 0.12.9-dev
│   │   │   ├── user-trades 0.12.9-dev
│   │   │   ├── stablesats 0.12.9-dev
│   │   │   ├── quotes-server 0.12.9-dev
│   │   │   │   └── stablesats 0.12.9-dev
│   │   │   └── hedging 0.12.9-dev
│   │   │       └── stablesats 0.12.9-dev
│   │   ├── stablesats 0.12.9-dev
│   │   ├── quotes-server 0.12.9-dev
│   │   ├── price-server 0.12.9-dev
│   │   │   └── stablesats 0.12.9-dev
│   │   ├── okex-price 0.12.9-dev
│   │   │   └── stablesats 0.12.9-dev
│   │   ├── hedging 0.12.9-dev
│   │   └── bria-client 0.12.9-dev
│   │       ├── stablesats 0.12.9-dev
│   │       └── hedging 0.12.9-dev
│   ├── stablesats 0.12.9-dev
│   ├── sqlx-ledger 0.11.5
│   │   └── stablesats-ledger 0.12.9-dev
│   ├── quotes-server 0.12.9-dev
│   ├── price-server 0.12.9-dev
│   ├── hedging 0.12.9-dev
│   ├── galoy-client 0.12.9-dev
│   │   ├── user-trades 0.12.9-dev
│   │   ├── stablesats 0.12.9-dev
│   │   └── hedging 0.12.9-dev
│   └── bria-client 0.12.9-dev
└── stablesats 0.12.9-dev
```