### PR TITLE
fix: validate OKX order books by sequence when checksum is zero

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3100,9 +3100,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/okex-price/src/convert.rs
+++ b/okex-price/src/convert.rs
@@ -54,6 +54,8 @@ impl TryFrom<OkexOrderBook> for OrderBookIncrement {
             bids: bids_map,
             timestamp: TimeStamp::try_from(ts)?,
             new_checksum: *checksum,
+            previous_sequence_id: okex_order_book_data.prev_seq_id,
+            sequence_id: okex_order_book_data.seq_id,
             action,
         };
         Ok(inner)

--- a/okex-price/src/error.rs
+++ b/okex-price/src/error.rs
@@ -35,6 +35,8 @@ pub enum PriceFeedError {
     InitialFullLoad,
     #[error("PriceFeedError: CheckSumValidation - Can't validate accuracy of depth data")]
     CheckSumValidation,
+    #[error("PriceFeedError: SequenceValidation - order book sequence discontinuity")]
+    SequenceValidation,
     #[error("PriceFeedError: StreamEnded - Stream ended unexpectedly")]
     StreamEnded,
     #[error("PriceFeedError: StreamStalled - Stream ended unexpectedly")]

--- a/okex-price/src/order_book/book.rs
+++ b/okex-price/src/order_book/book.rs
@@ -348,6 +348,18 @@ mod tests {
     }
 
     #[test]
+    fn deserializes_seq_ids_from_okx_json() -> anyhow::Result<()> {
+        let json = r#"{"arg":{"channel":"books","instId":"BTC-USD-SWAP"},
+            "action":"snapshot",
+            "data":[{"asks":[["62411.3","389.4","0","11"]],"bids":[["62411.2","66.3","0","3"]],
+                     "ts":"1700000000000","checksum":0,"prevSeqId":-1,"seqId":12345}]}"#;
+        let incr = OrderBookIncrement::try_from(serde_json::from_str::<OkexOrderBook>(json)?)?;
+        assert_eq!(incr.previous_sequence_id, Some(-1));
+        assert_eq!(incr.sequence_id, Some(12345));
+        Ok(())
+    }
+
+    #[test]
     fn merge_with_zero_checksums_accepts_sequence_resets() -> anyhow::Result<()> {
         let snapshot = load_order_book("snapshot")?;
 

--- a/okex-price/src/order_book/book.rs
+++ b/okex-price/src/order_book/book.rs
@@ -47,6 +47,10 @@ pub struct OrderBookChannelData {
     pub bids: Vec<PriceQuantity>,
     pub ts: TimeStampMilliStr,
     pub checksum: i32,
+    #[serde(default, rename = "prevSeqId")]
+    pub prev_seq_id: Option<i64>,
+    #[serde(default, rename = "seqId")]
+    pub seq_id: Option<i64>,
 }
 
 #[derive(Debug, Deserialize, Clone, Serialize)]
@@ -71,6 +75,10 @@ pub struct OrderBookIncrement {
     pub bids: BTreeMap<OrderPrice, Decimal>,
     pub timestamp: TimeStamp,
     pub new_checksum: i32,
+    #[serde(default)]
+    pub previous_sequence_id: Option<i64>,
+    #[serde(default)]
+    pub sequence_id: Option<i64>,
     pub action: OrderBookAction,
 }
 
@@ -80,15 +88,21 @@ pub struct CompleteOrderBook {
     bids: BTreeMap<OrderPrice, Decimal>,
     timestamp: TimeStamp,
     checksum: i32,
+    sequence_id: Option<i64>,
 }
 impl TryFrom<OrderBookIncrement> for CompleteOrderBook {
     type Error = PriceFeedError;
     fn try_from(book: OrderBookIncrement) -> Result<Self, Self::Error> {
+        if book.new_checksum == 0 && book.sequence_id.is_none() {
+            return Err(PriceFeedError::SequenceValidation);
+        }
+
         let result = CompleteOrderBook {
             asks: book.asks,
             bids: book.bids,
             timestamp: book.timestamp,
             checksum: book.new_checksum,
+            sequence_id: book.sequence_id,
         };
         result.verify_checksum()?;
         Ok(result)
@@ -98,6 +112,10 @@ impl TryFrom<OrderBookIncrement> for CompleteOrderBook {
 impl CompleteOrderBook {
     #[allow(clippy::result_large_err)]
     fn verify_checksum(&self) -> Result<(), PriceFeedError> {
+        if self.checksum == 0 {
+            return Ok(());
+        }
+
         let cs_res = self.calculate_checksum();
         if cs_res != self.checksum {
             return Err(PriceFeedError::CheckSumValidation);
@@ -107,12 +125,17 @@ impl CompleteOrderBook {
 
     #[allow(clippy::result_large_err)]
     fn try_merge(&self, increment: OrderBookIncrement) -> Result<Self, PriceFeedError> {
+        if increment.new_checksum == 0 {
+            self.verify_sequence(&increment)?;
+        }
+
         let new_book = match increment.action {
             OrderBookAction::Snapshot => CompleteOrderBook::try_from(increment)?,
             OrderBookAction::Update => {
                 let mut new_book = CompleteOrderBook {
                     timestamp: increment.timestamp,
                     checksum: increment.new_checksum,
+                    sequence_id: increment.sequence_id,
                     ..self.clone()
                 };
 
@@ -167,6 +190,23 @@ impl CompleteOrderBook {
             .collect::<String>();
 
         crc32fast::hash(crc.as_bytes()) as i32
+    }
+
+    fn verify_sequence(&self, increment: &OrderBookIncrement) -> Result<(), PriceFeedError> {
+        match (
+            self.sequence_id,
+            increment.previous_sequence_id,
+            increment.sequence_id,
+        ) {
+            (Some(current), Some(previous), Some(next)) => {
+                if current == previous && next >= previous {
+                    Ok(())
+                } else {
+                    Err(PriceFeedError::SequenceValidation)
+                }
+            }
+            _ => Err(PriceFeedError::SequenceValidation),
+        }
     }
 }
 
@@ -259,6 +299,60 @@ mod tests {
         let incr_3 = OrderBookIncrement::try_from(update_3)?;
         assert!(cache.update_order_book(incr_3.clone()).is_ok());
         assert_eq!(cache.latest().checksum, incr_3.new_checksum);
+
+        Ok(())
+    }
+
+    #[test]
+    fn merge_with_zero_checksums_uses_sequence_ids() -> anyhow::Result<()> {
+        let snapshot = load_order_book("snapshot")?;
+
+        let mut order_book_incr = OrderBookIncrement::try_from(snapshot)?;
+        order_book_incr.new_checksum = 0;
+        order_book_incr.previous_sequence_id = Some(-1);
+        order_book_incr.sequence_id = Some(10);
+        let mut cache = OrderBookCache::new(order_book_incr.try_into()?);
+
+        let update_1 = load_order_book("update-1")?;
+        let mut incr_1 = OrderBookIncrement::try_from(update_1)?;
+        incr_1.new_checksum = 0;
+        incr_1.previous_sequence_id = Some(10);
+        incr_1.sequence_id = Some(11);
+        assert!(cache.update_order_book(incr_1.clone()).is_ok());
+        assert_eq!(cache.latest().checksum, incr_1.new_checksum);
+        assert_eq!(cache.latest().sequence_id, incr_1.sequence_id);
+
+        let update_2 = load_order_book("update-2")?;
+        let mut incr_2 = OrderBookIncrement::try_from(update_2)?;
+        incr_2.new_checksum = 0;
+        incr_2.previous_sequence_id = Some(11);
+        incr_2.sequence_id = Some(12);
+        assert!(cache.update_order_book(incr_2.clone()).is_ok());
+        assert_eq!(cache.latest().checksum, incr_2.new_checksum);
+        assert_eq!(cache.latest().sequence_id, incr_2.sequence_id);
+
+        Ok(())
+    }
+
+    #[test]
+    fn merge_with_zero_checksums_rejects_sequence_gaps() -> anyhow::Result<()> {
+        let snapshot = load_order_book("snapshot")?;
+
+        let mut order_book_incr = OrderBookIncrement::try_from(snapshot)?;
+        order_book_incr.new_checksum = 0;
+        order_book_incr.previous_sequence_id = Some(-1);
+        order_book_incr.sequence_id = Some(10);
+        let mut cache = OrderBookCache::new(order_book_incr.try_into()?);
+
+        let update_1 = load_order_book("update-1")?;
+        let mut incr_1 = OrderBookIncrement::try_from(update_1)?;
+        incr_1.new_checksum = 0;
+        incr_1.previous_sequence_id = Some(9);
+        incr_1.sequence_id = Some(11);
+        assert!(matches!(
+            cache.update_order_book(incr_1),
+            Err(PriceFeedError::SequenceValidation)
+        ));
 
         Ok(())
     }

--- a/okex-price/src/order_book/book.rs
+++ b/okex-price/src/order_book/book.rs
@@ -93,8 +93,8 @@ pub struct CompleteOrderBook {
 impl TryFrom<OrderBookIncrement> for CompleteOrderBook {
     type Error = PriceFeedError;
     fn try_from(book: OrderBookIncrement) -> Result<Self, Self::Error> {
-        if book.new_checksum == 0 && book.sequence_id.is_none() {
-            return Err(PriceFeedError::SequenceValidation);
+        if book.new_checksum == 0 {
+            Self::verify_snapshot_sequence(&book)?;
         }
 
         let result = CompleteOrderBook {
@@ -125,13 +125,13 @@ impl CompleteOrderBook {
 
     #[allow(clippy::result_large_err)]
     fn try_merge(&self, increment: OrderBookIncrement) -> Result<Self, PriceFeedError> {
-        if increment.new_checksum == 0 {
-            self.verify_sequence(&increment)?;
-        }
-
         let new_book = match increment.action {
             OrderBookAction::Snapshot => CompleteOrderBook::try_from(increment)?,
             OrderBookAction::Update => {
+                if increment.new_checksum == 0 {
+                    self.verify_update_sequence(&increment)?;
+                }
+
                 let mut new_book = CompleteOrderBook {
                     timestamp: increment.timestamp,
                     checksum: increment.new_checksum,
@@ -192,14 +192,27 @@ impl CompleteOrderBook {
         crc32fast::hash(crc.as_bytes()) as i32
     }
 
-    fn verify_sequence(&self, increment: &OrderBookIncrement) -> Result<(), PriceFeedError> {
+    #[allow(clippy::result_large_err)]
+    fn verify_snapshot_sequence(book: &OrderBookIncrement) -> Result<(), PriceFeedError> {
+        match (
+            book.action.clone(),
+            book.previous_sequence_id,
+            book.sequence_id,
+        ) {
+            (OrderBookAction::Snapshot, Some(-1), Some(_)) => Ok(()),
+            _ => Err(PriceFeedError::SequenceValidation),
+        }
+    }
+
+    #[allow(clippy::result_large_err)]
+    fn verify_update_sequence(&self, increment: &OrderBookIncrement) -> Result<(), PriceFeedError> {
         match (
             self.sequence_id,
             increment.previous_sequence_id,
             increment.sequence_id,
         ) {
-            (Some(current), Some(previous), Some(next)) => {
-                if current == previous && next >= previous {
+            (Some(current), Some(previous), Some(_)) => {
+                if current == previous {
                     Ok(())
                 } else {
                     Err(PriceFeedError::SequenceValidation)
@@ -330,6 +343,87 @@ mod tests {
         assert!(cache.update_order_book(incr_2.clone()).is_ok());
         assert_eq!(cache.latest().checksum, incr_2.new_checksum);
         assert_eq!(cache.latest().sequence_id, incr_2.sequence_id);
+
+        Ok(())
+    }
+
+    #[test]
+    fn merge_with_zero_checksums_accepts_sequence_resets() -> anyhow::Result<()> {
+        let snapshot = load_order_book("snapshot")?;
+
+        let mut order_book_incr = OrderBookIncrement::try_from(snapshot)?;
+        order_book_incr.new_checksum = 0;
+        order_book_incr.previous_sequence_id = Some(-1);
+        order_book_incr.sequence_id = Some(15);
+        let mut cache = OrderBookCache::new(order_book_incr.try_into()?);
+
+        let update_1 = load_order_book("update-1")?;
+        let mut incr_1 = OrderBookIncrement::try_from(update_1)?;
+        incr_1.new_checksum = 0;
+        incr_1.previous_sequence_id = Some(15);
+        incr_1.sequence_id = Some(3);
+        assert!(cache.update_order_book(incr_1.clone()).is_ok());
+        assert_eq!(cache.latest().sequence_id, incr_1.sequence_id);
+
+        let update_2 = load_order_book("update-2")?;
+        let mut incr_2 = OrderBookIncrement::try_from(update_2)?;
+        incr_2.new_checksum = 0;
+        incr_2.previous_sequence_id = Some(3);
+        incr_2.sequence_id = Some(5);
+        assert!(cache.update_order_book(incr_2.clone()).is_ok());
+        assert_eq!(cache.latest().sequence_id, incr_2.sequence_id);
+
+        Ok(())
+    }
+
+    #[test]
+    fn zero_checksum_initial_book_must_be_snapshot() -> anyhow::Result<()> {
+        let update_1 = load_order_book("update-1")?;
+
+        let mut incr_1 = OrderBookIncrement::try_from(update_1)?;
+        incr_1.new_checksum = 0;
+        incr_1.previous_sequence_id = Some(10);
+        incr_1.sequence_id = Some(11);
+        assert!(matches!(
+            CompleteOrderBook::try_from(incr_1),
+            Err(PriceFeedError::SequenceValidation)
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn zero_checksum_initial_snapshot_requires_initial_previous_sequence() -> anyhow::Result<()> {
+        let snapshot = load_order_book("snapshot")?;
+
+        let mut order_book_incr = OrderBookIncrement::try_from(snapshot)?;
+        order_book_incr.new_checksum = 0;
+        order_book_incr.previous_sequence_id = Some(10);
+        order_book_incr.sequence_id = Some(11);
+        assert!(matches!(
+            CompleteOrderBook::try_from(order_book_incr),
+            Err(PriceFeedError::SequenceValidation)
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn zero_checksum_snapshot_replaces_cached_book() -> anyhow::Result<()> {
+        let snapshot = load_order_book("snapshot")?;
+
+        let mut order_book_incr = OrderBookIncrement::try_from(snapshot.clone())?;
+        order_book_incr.new_checksum = 0;
+        order_book_incr.previous_sequence_id = Some(-1);
+        order_book_incr.sequence_id = Some(10);
+        let mut cache = OrderBookCache::new(order_book_incr.try_into()?);
+
+        let mut replacement = OrderBookIncrement::try_from(snapshot)?;
+        replacement.new_checksum = 0;
+        replacement.previous_sequence_id = Some(-1);
+        replacement.sequence_id = Some(20);
+        assert!(cache.update_order_book(replacement.clone()).is_ok());
+        assert_eq!(cache.latest().sequence_id, replacement.sequence_id);
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

OKX deprecated order book checksums on June 23, 2026. The `books` channel now keeps the `checksum` field present but sets it to `0`, which caused `stablesats-price` to reject every order book snapshot and return `OrderBook: NoSnapshotAvailable`.

This updates OKX order book handling to accept `checksum == 0` and validate continuity using `seqId` / `prevSeqId` instead.

## Changes

- Parse OKX `seqId` and `prevSeqId` from order book payloads
- Preserve sequence IDs in `OrderBookIncrement` / `CompleteOrderBook`
- Skip checksum validation when OKX sends `checksum: 0`
- Validate update continuity using sequence IDs for zero-checksum books
- Add regression tests for zero-checksum updates and sequence gaps

## Verification

- Ran `nix develop -c cargo fmt -p okex-price`